### PR TITLE
Invoke resolve with route params & support resolve method defined on controller

### DIFF
--- a/src/Route.js
+++ b/src/Route.js
@@ -17,13 +17,18 @@ class Route {
     // Prepend URL with parent's URL
     url = (parent && parent.url) ? parent.url + url : url;
 
+    // Only 1 resolve definition allowed
+    if (controller && controller.resolve && resolve) {
+      throw new Error('Resolve cannot be defined on both controller and route.')
+    }
+
     this.Controller = controller // Controller definition
     this.controller = null // Controller instance
     this.name = name
     this.navigable = !!url && !abstract
     this.parent = parent || null
     this.path = path.concat(this)
-    this.resolve = resolve || {}
+    this.resolve = resolve || (controller && controller.resolve) || {}
     this.url = url
   }
 

--- a/src/Route.js
+++ b/src/Route.js
@@ -55,7 +55,7 @@ class Route {
    */
 
   enter(params = {}) {
-    let promise = getResolve(this.resolve)
+    let promise = getResolve(this.resolve, params)
 
     promise.then((resolve) => {
       if (this.Controller) {
@@ -88,36 +88,36 @@ class Route {
  * @returns {Promise}
  */
 
-function getResolve(value) {
+function getResolve(value, params) {
   if (value instanceof Promise) {
     return value
   }
 
   if (typeof value === 'function') {
-    return Promise.resolve(value())
+    return Promise.resolve(value(params))
   }
 
   if (_.isPlainObject(value)) {
-    return resolveObject(value)
+    return resolveObject(value, params)
   }
 
   if (Array.isArray(value)) {
     return Promise.all(value.map((item) => {
-      return (typeof item === 'function') ? item() : item
+      return (typeof item === 'function') ? item(params) : item
     }))
   }
 
   return Promise.resolve(value)
 }
 
-function resolveObject(obj) {
+function resolveObject(obj, params) {
   let keys = Object.keys(obj)
 
   // First invoke resolves and combine into single promise
   let combinedPromise = Promise.all(keys.map((key) => {
     let value = obj[key]
 
-    return (typeof value === 'function') ? value() : value
+    return (typeof value === 'function') ? value(params) : value
   }))
 
   // Then assign resolved values to their keys

--- a/src/spec/Route.spec.js
+++ b/src/spec/Route.spec.js
@@ -16,20 +16,21 @@ describe('Route:', () => {
   })
 
   describe('Resolve:', () => {
-    let controller, deferred, route;
+    let controller, deferred, route, resolve;
 
     beforeEach(() => {
       controller = jasmine.createSpy('controller')
       deferred = defer()
+      resolve = jasmine.createSpy('resolve').and.returnValue(deferred.promise)
 
       route = new Route({
         name: 'foo',
         controller: controller,
-        resolve: (() => deferred.promise),
+        resolve: resolve,
         path: []
       })
 
-      route.enter()
+      route.enter({ fooId: '1' })
     })
 
     it('Should resolve promises before controller instantiation.', () => {
@@ -47,11 +48,16 @@ describe('Route:', () => {
 
       return deferred.promise.then(() => {
         expect(controller).toHaveBeenCalledWith(
-          jasmine.any(Object), 'bar'
+          jasmine.objectContaining({ fooId: '1' }),
+          'bar'
         )
-
-        expect(controller.calls.mostRecent().args[0]).toEqual({})
       })
+    })
+
+    it('Should call resolve with route params.', () => {
+      expect(resolve).toHaveBeenCalledWith(
+        jasmine.objectContaining({ fooId: '1' })
+      )
     })
 
     it('Should instantiate the controller with named resolves.', () => {

--- a/src/spec/Route.spec.js
+++ b/src/spec/Route.spec.js
@@ -88,5 +88,53 @@ describe('Route:', () => {
         })
       })
     })
+
+    describe('Defined on Controller:', () => {
+      let deferred, route;
+
+      class Controller {
+        static resolve(routeParams) {}
+      }
+
+      beforeEach(() => {
+        deferred = defer()
+
+        spyOn(Controller, 'resolve').and.returnValue(deferred.promise)
+
+        route = new Route({
+          name: 'foo',
+          controller: Controller,
+          path: []
+        })
+      })
+
+      it("Should call a controller's static resolve method if defined.", () => {
+        route.enter()
+
+        expect(Controller.resolve).toHaveBeenCalled()
+      })
+
+      it("Should call a controller's static resolve method with route params.", () => {
+        route.enter({ fooId: '1' })
+
+        expect(Controller.resolve).toHaveBeenCalledWith(
+          jasmine.objectContaining({ fooId: '1' })
+        )
+      })
+
+      it('Should throw an error if resolve defined on both controller and route.', () => {
+        expect(() => {
+          new Route({
+            name: 'foo',
+            controller: Controller,
+            resolve: (() => deferred.promise),
+            path: []
+          })
+        }).toThrow(
+          new Error('Resolve cannot be defined on both controller and route.')
+        )
+      })
+    })
+
   })
 })


### PR DESCRIPTION
Adds support for the following syntax

``` js
class Controller() {
  static resolve(routeParams) {
    // return promise or other value to be resolved on route enter
  }
}
```
