### PR TITLE
feat(Transitions): add support for onStart transition hooks

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -3,6 +3,7 @@ import {isObject, isString} from './common'
 import Current from './Current'
 import Registry from './Registry'
 import Transition from './Transition'
+import Transitions from './Transitions'
 import UrlRouter from './UrlRouter'
 
 class Router {
@@ -11,6 +12,7 @@ class Router {
 
     this.urlRouter = new UrlRouter(prefix)
     this.registry = new Registry(this, this.urlRouter)
+    this.transitions = new Transitions()
 
     this.current = new Current(this, this.registry.root)
   }
@@ -160,7 +162,7 @@ class Router {
     // Default params to current
     params = Object.assign({}, this.current.params, params)
 
-    let transition = new Transition(exitPath, enterPath, params)
+    let transition = this.transitions.create(exitPath, enterPath, params)
 
     if (options.location) {
       this.pushState({}, route.title, this.href(route, params))

--- a/src/Transition.js
+++ b/src/Transition.js
@@ -1,3 +1,4 @@
+import {last} from './common'
 import Queue from './Queue'
 
 /**
@@ -7,7 +8,21 @@ import Queue from './Queue'
  */
 
 class Transition {
-  constructor(exitPath, enterPath, params) {
+
+  /**
+   * @param {Array.<Route>} exitPath
+   * @param {Array.<Route>} enterPath
+   * @param {Object} params
+   * @param {Transitions} transitions
+   */
+
+  constructor(exitPath, enterPath, params, transitions) {
+    let destination = last(enterPath)
+
+    this.onStartQueue = new Queue(transitions.onStartHandlers.map((handler) => {
+      return handler.bind(handler, destination)
+    }))
+
     this.exitQueue = new Queue(exitPath.map((route) => {
       return route.exit.bind(route)
     }))
@@ -18,7 +33,9 @@ class Transition {
   }
 
   run() {
-    return this.exitQueue.flush().then(() => this.enterQueue.flush())
+    return this.onStartQueue.flush()
+      .then(() => this.exitQueue.flush())
+      .then(() => this.enterQueue.flush())
   }
 }
 

--- a/src/Transitions.js
+++ b/src/Transitions.js
@@ -1,0 +1,46 @@
+import Transition from './Transition'
+
+/**
+ * @name Transitions
+ * @description
+ * Registers global transition hooks.
+ *
+ * @TODO
+ * - Implement additional transition lifecycle hooks
+ * - Support handlers returning Boolean
+ * - Write tests
+ */
+
+class Transitions {
+  constructor(){
+    this.onStartHandlers = []
+  }
+
+  /**
+   * @method onStart
+   * @description
+   * Registers a callback handler called on transition start.
+   * Handler may return a promise to cancel route transition.
+   *
+   * @TODO support returning Boolean to cancel or continue transition.
+   *
+   * @param {Function} handler
+   *
+   * @callback handler
+   * @param {Route} destination
+   */
+
+  onStart(handler) {
+    if (typeof handler !== 'function') {
+      throw new Error(`Handler must be a function, was '${typeof handler}' instead`)
+    }
+
+    this.onStartHandlers.push(handler)
+  }
+
+  create(exitPath, enterPath, params) {
+    return new Transition(exitPath, enterPath, params, this)
+  }
+}
+
+export default Transitions

--- a/src/common.js
+++ b/src/common.js
@@ -11,3 +11,7 @@ export function defer() {
 
   return { resolve, reject, promise}
 }
+
+export function last(arr) {
+  return arr[arr.length - 1]
+}

--- a/src/spec/Router.spec.js
+++ b/src/spec/Router.spec.js
@@ -342,10 +342,11 @@ describe('Router:', () => {
       })
 
       it("Should call controller's exit handler when exiting a route.", () => {
-        return router.go('gizmo')
-          .then(() => {
-            router.go('home')
+        deferred.resolve('onExit')
 
+        return router.go('gizmo')
+          .then(() => router.go('home'))
+          .then(() => {
             expect(onExit).toHaveBeenCalled()
           })
       })


### PR DESCRIPTION
In additional to rejecting a resolve, an onStart transition hook can return a rejected promise to cancel a route transition. Useful for checking authentication, permissions, etc.
